### PR TITLE
Sprint 32 Upgrade base vm to ubuntu trusty

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,11 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise64"
-
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "ubuntu/trusty64"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
@@ -102,10 +98,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     shell.args = %q{/etc/sudoers.d/root_ssh_agent "Defaults    env_keep += \"SSH_AUTH_SOCK\""}
   end
 
-  # Prepare for mongodb installation
+  # install puppet apt modules
   config.vm.provision :shell do |shell|
-    shell.inline = "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10;
-                    echo 'deb http://repo.mongodb.org/apt/ubuntu '$(lsb_release -sc)'/mongodb-org/3.0 multiverse' | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list"
+      shell.inline = "$(sudo puppet module list | grep -q puppetlabs-apt) || sudo puppet module install puppetlabs-apt"
   end
 
   config.vm.provision :puppet do |puppet|


### PR DESCRIPTION
* use ubuntu's box (more recent updates) over hashicorp's version
* start using puppet apt module to add apt sources
* add official postgres apt source, so we get a json-capable postgres server
* add canvas_admin_tools as venv to create
* all unit tests from created virtualenvs passed, modulo canvas_course_creation (errors looked to be unrelated...settings missing, etc)