### PR TITLE
Make postgres accessible from the vagrant host

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 8001, host: 8001, auto_correct: true
   config.vm.network :forwarded_port, guest: 8002, host: 8002, auto_correct: true
 
+  config.vm.network :forwarded_port, guest: 5432, host: 15432
+
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   # Uncomment when using NFS synced folders


### PR DESCRIPTION
* adds lines to the postgres config files to listen on all interfaces,
  and accept md5 logins from all ipv4 addresses.
* bounces the postgres service after those changes have been made.
* exposes the postgres server on port 15432 on the vagrant host.

After running `vagrant up`, the postgres server is accessible via
```$ psql -h 127.0.0.1 -U vagrant -p 15432 -W vagrant```