### PR TITLE
Don't source install our library projects on venv create

### DIFF
--- a/vagrant/bin/venv_bootstrap.sh
+++ b/vagrant/bin/venv_bootstrap.sh
@@ -6,5 +6,4 @@ source /usr/local/bin/virtualenvwrapper.sh
 
 mkvirtualenv -a /home/vagrant/tlt/$1 $1 \
 	&& workon $1 \
-	&& pip install -r /home/vagrant/tlt/${1}/${1}/requirements/local.txt \
-	&& pip install -r /vagrant/vagrant/requirements/base.txt
+	&& pip install -r /home/vagrant/tlt/${1}/${1}/requirements/local.txt

--- a/vagrant/requirements/base.txt
+++ b/vagrant/requirements/base.txt
@@ -1,5 +1,0 @@
--e /home/vagrant/tlt/canvas_python_sdk
--e /home/vagrant/tlt/django-auth-lti
--e /home/vagrant/tlt/django-icommons-common
--e /home/vagrant/tlt/django-icommons-ui
--e /home/vagrant/tlt/django-canvas-course-site-wizard


### PR DESCRIPTION
It's way too easy to leave those projects in a weird state, thus hosing your work.  Instead, let's install the released versions in the requirements file.