### PR TITLE
bump version in paths to 9.5

### DIFF
--- a/vagrant/manifests/default.pp
+++ b/vagrant/manifests/default.pp
@@ -226,28 +226,28 @@ exec {'create-postgresql-db':
 # ensure the postgresql config allows connections from vagrant host
 # NOTE: this will need updating if we change postgresql minor versions
 
-file {'/etc/postgresql/9.4/main/postgresql.conf':
+file {'/etc/postgresql/9.5/main/postgresql.conf':
     require => Package['postgresql'],
     ensure => 'present',
 }
 
 file_line {'postgresql-conf-listen':
     require => [Package['postgresql'],
-                File['/etc/postgresql/9.4/main/postgresql.conf']],
-    path => '/etc/postgresql/9.4/main/postgresql.conf',
+                File['/etc/postgresql/9.5/main/postgresql.conf']],
+    path => '/etc/postgresql/9.5/main/postgresql.conf',
     line => "listen_addresses = '*'",
     notify => Service['postgresql'],
 }
 
-file {'/etc/postgresql/9.4/main/pg_hba.conf':
+file {'/etc/postgresql/9.5/main/pg_hba.conf':
     require => Package['postgresql'],
     ensure => 'present',
 }
 
 file_line {'pg-hba-conf-listen':
     require => [Package['postgresql'],
-                File['/etc/postgresql/9.4/main/pg_hba.conf']],
-    path => '/etc/postgresql/9.4/main/pg_hba.conf',
+                File['/etc/postgresql/9.5/main/pg_hba.conf']],
+    path => '/etc/postgresql/9.5/main/pg_hba.conf',
     line => 'host    all     all     0.0.0.0/0       md5',
     notify => Service['postgresql'],
 }


### PR DESCRIPTION
Creating a new vm with the updates from https://github.com/Harvard-University-iCommons/tlt-vagrant/pull/12 fails due to the fact that the vm now has postgres 9.5 installed, not 9.4.  This updates the paths accordingly.

NOTE: @bermudezjd warns that we're not yet on 9.5 on AWS.  I'm not a fan of introducing version skew between dev and prod environments, but I doubt this is the only difference, and I don't want to go down the path of having to maintain a list of pegged package versions to match what's on AWS.  If someone else wants to do that, I'm happy to chuck this.  But for now, I'd like a clean-environment `vagrant up` to Just Work.