### PR TITLE
removes unnecessary postgres port forwarding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,8 +22,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 8001, host: 8001, auto_correct: true
   config.vm.network :forwarded_port, guest: 8002, host: 8002, auto_correct: true
 
-  config.vm.network :forwarded_port, guest: 5432, host: 15432
-
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   # Uncomment when using NFS synced folders


### PR DESCRIPTION
- vm postgres can be accessed by development tools on host via ssh tunneling, so explicit port forwarding is extraneous