### PR TITLE
Latest version of postgres on Ubuntu 14.04 is 9.6.  Update hardcoded …

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,7 +104,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # install puppet apt modules
   config.vm.provision :shell do |shell|
-      shell.inline = "$(sudo puppet module list | grep -q puppetlabs-apt) || sudo puppet module install puppetlabs-apt"
+      shell.inline = "$(sudo puppet module list | grep -q puppetlabs-apt) || sudo puppet module install puppetlabs-apt --version 2.4.0"
   end
 
   # install non-broken pip module to fix https issue when pulling 'latest' from pip

--- a/vagrant/manifests/default.pp
+++ b/vagrant/manifests/default.pp
@@ -206,7 +206,7 @@ package {'firefox':
 }
 
 # Install Postgresql
-$pg_major_version = 9.5  # The major version of postgres we're installing
+$pg_major_version = 9.6  # The major version of postgres we're installing
 package {'postgresql':
     name => "postgresql-$pg_major_version",
     ensure => latest,

--- a/vagrant/manifests/default.pp
+++ b/vagrant/manifests/default.pp
@@ -233,28 +233,28 @@ exec {'create-postgresql-db':
 # ensure the postgresql config allows connections from vagrant host
 # NOTE: this will need updating if we change postgresql minor versions
 
-file {'/etc/postgresql/9.5/main/postgresql.conf':
+file {'/etc/postgresql/9.6/main/postgresql.conf':
     require => Package['postgresql'],
     ensure => 'present',
 }
 
 file_line {'postgresql-conf-listen':
     require => [Package['postgresql'],
-                File['/etc/postgresql/9.5/main/postgresql.conf']],
-    path => '/etc/postgresql/9.5/main/postgresql.conf',
+                File['/etc/postgresql/9.6/main/postgresql.conf']],
+    path => '/etc/postgresql/9.6/main/postgresql.conf',
     line => "listen_addresses = '*'",
     notify => Service['postgresql'],
 }
 
-file {'/etc/postgresql/9.5/main/pg_hba.conf':
+file {'/etc/postgresql/9.6/main/pg_hba.conf':
     require => Package['postgresql'],
     ensure => 'present',
 }
 
 file_line {'pg-hba-conf-listen':
     require => [Package['postgresql'],
-                File['/etc/postgresql/9.5/main/pg_hba.conf']],
-    path => '/etc/postgresql/9.5/main/pg_hba.conf',
+                File['/etc/postgresql/9.6/main/pg_hba.conf']],
+    path => '/etc/postgresql/9.6/main/pg_hba.conf',
     line => 'host    all     all     0.0.0.0/0       md5',
     notify => Service['postgresql'],
 }

--- a/vagrant/manifests/default.pp
+++ b/vagrant/manifests/default.pp
@@ -185,7 +185,7 @@ package {'nodejs':
 package {'ntp':
     ensure => latest,
     require => Exec['apt-get-update'],
-} 
+}
 
 service {'ntp':
     ensure => running,
@@ -206,12 +206,15 @@ package {'firefox':
 }
 
 # Install Postgresql
+$pg_major_version = 9.5  # The major version of postgres we're installing
 package {'postgresql':
+    name => "postgresql-$pg_major_version",
     ensure => latest,
     require => Exec['apt-get-update'],
 }
 
 package {'postgresql-contrib':
+    name => "postgresql-contrib-$pg_major_version",
     ensure => latest,
     require => Exec['apt-get-update'],
 }
@@ -233,28 +236,28 @@ exec {'create-postgresql-db':
 # ensure the postgresql config allows connections from vagrant host
 # NOTE: this will need updating if we change postgresql minor versions
 
-file {'/etc/postgresql/9.6/main/postgresql.conf':
+file {"/etc/postgresql/$pg_major_version/main/postgresql.conf":
     require => Package['postgresql'],
     ensure => 'present',
 }
 
 file_line {'postgresql-conf-listen':
     require => [Package['postgresql'],
-                File['/etc/postgresql/9.6/main/postgresql.conf']],
-    path => '/etc/postgresql/9.6/main/postgresql.conf',
+                File["/etc/postgresql/$pg_major_version/main/postgresql.conf"]],
+    path => "/etc/postgresql/$pg_major_version/main/postgresql.conf",
     line => "listen_addresses = '*'",
     notify => Service['postgresql'],
 }
 
-file {'/etc/postgresql/9.6/main/pg_hba.conf':
+file {"/etc/postgresql/$pg_major_version/main/pg_hba.conf":
     require => Package['postgresql'],
     ensure => 'present',
 }
 
 file_line {'pg-hba-conf-listen':
     require => [Package['postgresql'],
-                File['/etc/postgresql/9.6/main/pg_hba.conf']],
-    path => '/etc/postgresql/9.6/main/pg_hba.conf',
+                File["/etc/postgresql/$pg_major_version/main/pg_hba.conf"]],
+    path => "/etc/postgresql/$pg_major_version/main/pg_hba.conf",
     line => 'host    all     all     0.0.0.0/0       md5',
     notify => Service['postgresql'],
 }


### PR DESCRIPTION
…references for 9.5 to 9.6.

NOTE: this update requires reprovisioning of your VM in order to upgrade the postgres library.

@elliottyates 
@sapnamysore 
@cmsnowden 
